### PR TITLE
New feature in SheetSplitter: Hold Trim

### DIFF
--- a/src/client/resources/static/localization/en.csv
+++ b/src/client/resources/static/localization/en.csv
@@ -135,3 +135,5 @@ SELECT_TEXTURE;Texture
 SELECT_DATA_FILE;Data file
 SPLITTER;Split sheet
 SPLITTER_ERROR_NO_FRAMES;Sprites not found. Probably, atlas format is incorrect.
+HOLD_TRIM;Hold Trim
+HOLD_TRIM_TITLE;Hold trim option

--- a/src/client/resources/static/localization/es.csv
+++ b/src/client/resources/static/localization/es.csv
@@ -135,3 +135,5 @@ SELECT_TEXTURE;Textura
 SELECT_DATA_FILE;Datos
 SPLITTER;Desembalaje atlas
 SPLITTER_ERROR_NO_FRAMES;No se ha encontrado ningún sprite. Quizás el formato del atlas sea incorrecto.
+HOLD_TRIM;Mantener corte
+HOLD_TRIM_TITLE;Mantener la opción de corte

--- a/src/client/resources/static/localization/ru.csv
+++ b/src/client/resources/static/localization/ru.csv
@@ -135,3 +135,5 @@ SELECT_TEXTURE;Текстура
 SELECT_DATA_FILE;Данные
 SPLITTER;Распаковка атласа
 SPLITTER_ERROR_NO_FRAMES;Не найдено ни одного спрайта. Возможно, формат атласа неверен.
+HOLD_TRIM;Hold Trim
+HOLD_TRIM_TITLE;Hold trim optin


### PR DESCRIPTION
I think that is a good feature to complete the tool. You can split your atlas in two ways: original components or trimmed components.

Take a look! 

Please review your language in this feature. Thanks.