### PR TITLE
XML declaration moved before first comment.

### DIFF
--- a/src/client/resources/static/exporters/Starling.mst
+++ b/src/client/resources/static/exporters/Starling.mst
@@ -1,7 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Created with {{appInfo.displayName}} v{{appInfo.version}} {{{appInfo.url}}}
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <TextureAtlas imagePath="{{{config.imageFile}}}" width="{{config.imageWidth}}" height="{{config.imageHeight}}">
   {{#rects}}
   <SubTexture name="{{{name}}}" x="{{frame.x}}" y="{{frame.y}}" {{#rotated}}width="{{frame.h}}" height="{{frame.w}}" rotated="true"{{/rotated}} {{^rotated}}width="{{frame.w}}" height="{{frame.h}}"{{/rotated}} frameX="-{{spriteSourceSize.x}}" frameY="-{{spriteSourceSize.y}}" frameWidth="{{sourceSize.w}}" frameHeight="{{sourceSize.h}}"/>

--- a/src/client/resources/static/exporters/XML.mst
+++ b/src/client/resources/static/exporters/XML.mst
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Created with {{appInfo.displayName}} v{{appInfo.version}} {{{appInfo.url}}}
 Format:
@@ -13,7 +14,6 @@ oY => y-corner offset
 oW => original width
 oH => original height
 r => 'y' if sprite is rotated-->
-<?xml version="1.0" encoding="UTF-8"?>
 <TextureAtlas imagePath="{{config.imageFile}}" width="{{config.imageWidth}}" height="{{config.imageHeight}}" scale="{{config.scale}}" format="{{config.format}}">
   {{#rects}}
   <sprite n="{{{name}}}" x="{{frame.x}}" y="{{frame.y}}" w="{{frame.w}}" h="{{frame.h}}" pX="0.5" pY="0.5"{{#trimmed}} oX="{{spriteSourceSize.x}}" oY="{{spriteSourceSize.y}}" oW="{{sourceSize.w}}" oH="{{sourceSize.h}}"{{/trimmed}}{{#rotated}} r="y"{{/rotated}}/>


### PR DESCRIPTION
Hi there, 

Great tool! I made a very small patch for XML exporters. The XML format requires that the XML declaration need to be before any other element. Some XML parsers return an error when a comment is placed before it (like `sprite-sheet-to-x3d` from Castle Game Engine).

More info: https://stackoverflow.com/questions/1196467/ok-to-put-comments-before-the-xml-declaration

Regards