### PR TITLE
Name of language in separate file

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -10,6 +10,7 @@ let RECENT_PROJECTS = [];
 let CURRENT_LOCALE = "";
 let LOCALE_STRINGS = {};
 let APP_INFO = {};
+let LANGUAGES = [];
 let CURRENT_PROJECT = "";
 let CURRENT_PROJECT_MODIFIED = false;
 
@@ -238,12 +239,12 @@ function buildMenu() {
     });
     
     let langs = [];
-    if(APP_INFO.localizations) {
-        for (let lang of APP_INFO.localizations) {
+    if(LANGUAGES !== []) {
+        for (let lang of LANGUAGES) {
             langs.push({
-                label: LOCALE_STRINGS['LANGUAGE_' + lang],
-                custom: lang,
-                checked: CURRENT_LOCALE === lang,
+                label: lang.name,
+                custom: lang.lang,
+                checked: CURRENT_LOCALE === lang.lang,
                 type: 'checkbox',
                 actionName: 'change-locale',
                 click: sendMessage
@@ -355,6 +356,11 @@ ipcMain.on('update-app-info', (e, data) => {
     APP_INFO = data;
     buildMenu();
     updateWindowTitle();
+});
+
+ipcMain.on('update-languages', (e, data) => {
+    LANGUAGES = data;
+    buildMenu();
 });
 
 ipcMain.on('update-locale', (e, data) => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -8,7 +8,7 @@ import MainLayout from './ui/MainLayout.jsx';
 import Storage from './utils/Storage';
 import {Observer, GLOBAL_EVENT} from './Observer';
 
-import appInfo from '../../package.json';
+import languages from './resources/static/localization/languages.json';
 
 import Controller from 'platform/Controller';
 
@@ -26,7 +26,9 @@ function run() {
 }
 
 function loadLocalization() {
-    I18.supportedLanguages = appInfo.localizations.slice();
+    for(let i = 1; i < languages.length; i++) {
+        I18.supportedLanguages.push(languages[i].lang);
+    }
     I18.path = "static/localization";
     I18.init(Storage.load(STORAGE_LANGUAGE_KEY, false));
 

--- a/src/client/platform/electron/Controller.js
+++ b/src/client/platform/electron/Controller.js
@@ -3,6 +3,7 @@ const {ipcRenderer} = require('electron');
 import {GLOBAL_EVENT, Observer} from "../../Observer";
 import I18 from '../../utils/I18';
 import appInfo from '../../../../package.json';
+import languages from '../../resources/static/localization/languages.json';
 
 import Project from 'platform/Project';
 
@@ -87,6 +88,7 @@ class Controller {
         });
 
         ipcRenderer.send('update-app-info', appInfo);
+        ipcRenderer.send('update-languages', languages);
         
         Controller.updateRecentProjects();
         

--- a/src/client/resources/static/localization/en.csv
+++ b/src/client/resources/static/localization/en.csv
@@ -5,9 +5,6 @@ CANCEL;CANCEL
 SAVE;SAVE
 IMAGES;Images
 LANGUAGE;language:
-LANGUAGE_en;english
-LANGUAGE_es;español
-LANGUAGE_ru;русский
 ADD_IMAGES;Add images
 ADD_IMAGES_TITLE;Add images
 ADD_FOLDER;Add folder

--- a/src/client/resources/static/localization/es.csv
+++ b/src/client/resources/static/localization/es.csv
@@ -5,9 +5,6 @@ CANCEL;CANCELAR
 SAVE;GUARDAR
 IMAGES;Imágenes
 LANGUAGE;Idioma:
-LANGUAGE_en;english
-LANGUAGE_es;español
-LANGUAGE_ru;русский
 ADD_IMAGES;Añadir imágenes
 ADD_IMAGES_TITLE;Añadir imágenes
 ADD_FOLDER;Añadir carpeta

--- a/src/client/resources/static/localization/languages.json
+++ b/src/client/resources/static/localization/languages.json
@@ -1,0 +1,5 @@
+[
+    { "lang": "en", "name": "english" },
+    { "lang": "es", "name": "español" },
+    { "lang": "ru", "name": "русский"}
+]

--- a/src/client/resources/static/localization/ru.csv
+++ b/src/client/resources/static/localization/ru.csv
@@ -5,9 +5,6 @@ CANCEL;ОТМЕНА
 SAVE;СОХРАНИТЬ
 IMAGES;Изображения
 LANGUAGE;язык:
-LANGUAGE_en;english
-LANGUAGE_es;español
-LANGUAGE_ru;русский
 ADD_IMAGES;Добавить
 ADD_IMAGES_TITLE;Добавить изображения
 ADD_FOLDER;Добавить папку

--- a/src/client/ui/MainHeader.jsx
+++ b/src/client/ui/MainHeader.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {Observer, GLOBAL_EVENT} from '../Observer';
 import I18 from '../utils/I18';
 import appInfo from '../../../package.json';
+import languages from '../resources/static/localization/languages.json';
 
 class MainHeader extends React.Component {
     constructor(props) {
@@ -39,10 +40,10 @@ class MainHeader extends React.Component {
                     {I18.f("LANGUAGE")}
                     <select defaultValue={I18.currentLocale} onChange={this.changeLanguage}>
                         {
-                            appInfo.localizations.map((item) => {
+                            languages.map((item) => {
                                 return (
-                                    <option key={"localization_" + item} value={item}>
-                                        {I18.f("LANGUAGE_" + item)}
+                                    <option key={"localization_" + item} value={item.lang}>
+                                        {item.name}
                                     </option>
                                 )
                             })


### PR DESCRIPTION
While creating the German translation I noticed that the language name has to be added to every language file. #29 

In this pull request I have changed the code to use the name from a new file `src/client/resources/static/localization/languages.json`. This way you do not have to modify every language file while adding a new language.