### PR TITLE
Correct behaviour in pack properties and fixed issue in save project

### DIFF
--- a/src/client/ui/PackProperties.jsx
+++ b/src/client/ui/PackProperties.jsx
@@ -261,9 +261,10 @@ class PackProperties extends React.Component {
 
         let exporter = getExporterByType(this.packOptions.exporter);
         let allowRotation = this.packOptions.allowRotation && exporter.allowRotation;
-        let exporterRotationDisabled = exporter.allowRotation ? "" : "disabled";
+        let rotationDisabled = this.packOptions.packer !== 'OptimalPacker' && exporter.allowRotation ? "" : "disabled";
         let allowTrim = this.packOptions.allowTrim && exporter.allowTrim;
         let exporterTrimDisabled = exporter.allowTrim ? "" : "disabled";
+        let methodDisabled = this.packOptions.packer !== 'OptimalPacker' ? "" : "disabled";
         
         return (
             <div className="props-list back-white">
@@ -394,7 +395,7 @@ class PackProperties extends React.Component {
                             </tr>
                             <tr title={I18.f("ALLOW_ROTATION_TITLE")}>
                                 <td>{I18.f("ALLOW_ROTATION")}</td>
-                                <td><input ref="allowRotation" type="checkbox" className="border-color-gray" onChange={this.onPropChanged} defaultChecked={allowRotation ? "checked" : ""} disabled={exporterRotationDisabled} /></td>
+                                <td><input ref="allowRotation" type="checkbox" className="border-color-gray" onChange={this.onPropChanged} defaultChecked={allowRotation ? "checked" : ""} disabled={rotationDisabled} /></td>
                                 <td></td>
                             </tr>
                             <tr title={I18.f("ALLOW_TRIM_TITLE")}>
@@ -435,7 +436,7 @@ class PackProperties extends React.Component {
                             </tr>
                             <tr title={I18.f("PACKER_METHOD_TITLE")}>
                                 <td>{I18.f("PACKER_METHOD")}</td>
-                                <td><PackerMethods ref="packerMethod" packer={this.state.packer} defaultMethod={this.packOptions.packerMethod} handler={this.onPropChanged}/></td>
+                                <td><PackerMethods ref="packerMethod" packer={this.state.packer} defaultMethod={this.packOptions.packerMethod} handler={this.onPropChanged} disabled={methodDisabled}/></td>
                                 <td></td>
                             </tr>
                         </tbody>
@@ -462,7 +463,9 @@ class PackerMethods extends React.Component {
         }
 
         return (
-            <select onChange={this.props.handler} className="border-color-gray" defaultValue={this.props.defaultMethod} >{items}</select>
+            <select onChange={this.props.handler} className="border-color-gray" defaultValue={this.props.defaultMethod} disabled={this.props.disabled}>
+                {items}
+            </select>
         )
     }
 }

--- a/src/client/utils/LocalImagesLoader.js
+++ b/src/client/utils/LocalImagesLoader.js
@@ -35,11 +35,16 @@ class LocalImagesLoader {
         
         if(types.indexOf(item.type) >= 0) {
             let img = new Image();
+            img.fsPath = {
+                folder: '',
+                name: item.name,
+                path: item.path
+            };
 
-            let reader = new FileReader();
+            let reader = new FileReader();            
             reader.onload = e => {
                 img.src = e.target.result;
-                img._base64 = e.target.result;
+                img._base64 = e.target.result;                
 
                 this.loaded[item.name] = img;
                 this.loadedCnt++;


### PR DESCRIPTION
**Changed:** Checkbox rotation disabled when OptimalPacker is selected too.
**Changed:** Method select component disabled when OptimalPacker is selected because it has 'Automatic' method only.

There is an issue #41 where the user asks about rotation feature. I think that this PR can help him.