### PR TITLE
Adjusted Godot Atlas exporter to take margins into account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,11 @@
 
 node_modules/*
 
+dist/*
+
 package-lock.json
+
+yarn.lock
 
 .DS_Store
 /index.js

--- a/src/client/exporters/index.js
+++ b/src/client/exporters/index.js
@@ -81,9 +81,10 @@ function prepareData(data, options) {
             name = name.split("/").pop();
         }
 
-        let frame = {x: item.frame.x, y: item.frame.y, w: item.frame.w, h: item.frame.h, hw: item.frame.w/2, hh: item.frame.h/2};
+        let frame = {x: item.frame.x, y: item.frame.y, w: item.frame.w, h: item.frame.h, hw: item.frame.w/2, hh: item.frame.h/2, mx: 0, my:0, mw:item.spriteSourceSize.w-item.frame.w, mh:item.spriteSourceSize.h-item.frame.h};
         let spriteSourceSize = {x: item.spriteSourceSize.x, y: item.spriteSourceSize.y, w: item.spriteSourceSize.w, h: item.spriteSourceSize.h};
         let sourceSize = {w: item.sourceSize.w, h: item.sourceSize.h};
+        let margin = {x: (sourceSize.w - spriteSourceSize.w)/2, y: (sourceSize.h - spriteSourceSize.h)/2, h: sourceSize.h - spriteSourceSize.h, w: sourceSize.w - spriteSourceSize.w}
         
         let trimmed = item.trimmed;
         
@@ -102,6 +103,10 @@ function prepareData(data, options) {
             frame.h *= opt.scale;
             frame.hw *= opt.scale;
             frame.hh *= opt.scale;
+            margin.x *= opt.scale;
+            margin.y *= opt.scale;
+            margin.w *= opt.scale;
+            margin.h *= opt.scale;
 
             spriteSourceSize.x *= opt.scale;
             spriteSourceSize.y *= opt.scale;
@@ -117,6 +122,7 @@ function prepareData(data, options) {
             frame: frame,
             spriteSourceSize: spriteSourceSize,
             sourceSize: sourceSize,
+            margin: margin,
             rotated: item.rotated,
             trimmed: trimmed
         });

--- a/src/client/exporters/index.js
+++ b/src/client/exporters/index.js
@@ -81,9 +81,11 @@ function prepareData(data, options) {
             name = name.split("/").pop();
         }
 
-        let frame = {x: item.frame.x, y: item.frame.y, w: item.frame.w, h: item.frame.h, hw: item.frame.w/2, hh: item.frame.h/2, mx: 0, my:0, mw:item.spriteSourceSize.w-item.frame.w, mh:item.spriteSourceSize.h-item.frame.h};
+        let frame = {x: item.frame.x, y: item.frame.y, w: item.frame.w, h: item.frame.h, hw: item.frame.w/2, hh: item.frame.h/2};
         let spriteSourceSize = {x: item.spriteSourceSize.x, y: item.spriteSourceSize.y, w: item.spriteSourceSize.w, h: item.spriteSourceSize.h};
         let sourceSize = {w: item.sourceSize.w, h: item.sourceSize.h};
+
+        //Used when importing to Godot Atlas to retain the original sprite size
         let margin = {x: (sourceSize.w - spriteSourceSize.w)/2, y: (sourceSize.h - spriteSourceSize.h)/2, h: sourceSize.h - spriteSourceSize.h, w: sourceSize.w - spriteSourceSize.w}
         
         let trimmed = item.trimmed;

--- a/src/client/exporters/list.json
+++ b/src/client/exporters/list.json
@@ -51,15 +51,15 @@
     "type": "Godot (atlas)",
     "description": "Godot Atlas format",
     "allowTrim": true,
-    "allowRotation": true,
+    "allowRotation": false,
     "template": "GodotAtlas.mst",
     "fileExt": "tpsheet"
   },
   {
     "type": "Godot (tileset)",
-    "description": "Godot Tileset format",
+    "description": "Godot Tileset format (3.x only)",
     "allowTrim": true,
-    "allowRotation": true,
+    "allowRotation": false,
     "template": "GodotTileset.mst",
     "fileExt": "tpset"
   },

--- a/src/client/resources/static/exporters/GodotAtlas.mst
+++ b/src/client/resources/static/exporters/GodotAtlas.mst
@@ -19,8 +19,8 @@
 					"margin": {
 						"x": 0,
 						"y": 0,
-						"w": 0,
-						"h": 0
+						"w": {{32 - frame.w}},
+						"h": {{32 - frame.h}}
 					}
 				}{{^last}},{{/last}}
 				{{/rects}}

--- a/src/client/resources/static/exporters/GodotAtlas.mst
+++ b/src/client/resources/static/exporters/GodotAtlas.mst
@@ -17,10 +17,10 @@
 						"h": {{frame.h}}
 					},
 					"margin": {
-						"x": 0,
-						"y": 0,
-						"w": {{32 - frame.w}},
-						"h": {{32 - frame.h}}
+						"x": {{margin.x}},
+						"y": {{margin.y}},
+						"w": {{margin.w}},
+						"h": {{margin.h}}
 					}
 				}{{^last}},{{/last}}
 				{{/rects}}


### PR DESCRIPTION
When using the tool as an alternative to Texture Packer in Godot 4 I noticed that the margins were all set to 0 resulting in either a lot of fixing by hand or being left with sprites unusable for animation.